### PR TITLE
fix: Update git hash in instructions to match latest changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This module will not receive updates in the future, it is only intended to help 
     module "eks" {
     -  source  = "terraform-aws-modules/eks/aws"
     -  version = "~> 19.21"
-    +  source  = "git@github.com:clowdhaus/terraform-aws-eks-v20-migrate.git?ref=c356ac8ec211604defaaaad49d27863d1e8a1391"
+    +  source  = "git@github.com:clowdhaus/terraform-aws-eks-v20-migrate.git?ref=3f626cc493606881f38684fc366688c36571c5c5"
     }
     ```
 3. Review the upgrade guide for `v20.0.0` and make any necessary changes to your module definition


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

According to this [commit ](https://github.com/clowdhaus/terraform-aws-eks-migrate-v19-to-v20/commit/3f626cc493606881f38684fc366688c36571c5c5) the way access entry is created in the parent repo has been fixed. But the readme hash is still a month old hash. So I have fixed it with the latest hash

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This change is required other wise users migrating to v20 following this migration will not able able to successfully migrate as access entry policies added by them will be deleted in the final step of migration

This fixes the issue https://github.com/terraform-aws-modules/terraform-aws-eks/issues/2958

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I confirmed by running terraform apply in last step using this hash during migration that only config map is deleted and not the associated access policy in step 3 of migration

## Screenshots (if appropriate):
