### PR TITLE
docs: Correct hash for git diff in step 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This module will not receive updates in the future, it is only intended to help 
 5. Once the changes have been applied and you confirm that necessary access entries are present in the cluster, change the source of your module back to the `terraform-aws-eks` module using the appropriate version
     ```diff
     module "eks" {
-    -  source  = "git@github.com:clowdhaus/terraform-aws-eks-v20-migrate.git?ref=c356ac8ec211604defaaaad49d27863d1e8a1391"
+    -  source  = "git@github.com:clowdhaus/terraform-aws-eks-v20-migrate.git?ref=3f626cc493606881f38684fc366688c36571c5c5"
     +  source  = "terraform-aws-modules/eks/aws"
     +  version = "~> 20.0"
     }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

In the [previous MR](https://github.com/clowdhaus/terraform-aws-eks-migrate-v19-to-v20/pull/4) I have fixed  the hash for step 2, however step 5 git diff still shows the old hash. so I have fixed it.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

It fixes https://github.com/clowdhaus/terraform-aws-eks-migrate-v19-to-v20/issues/5

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
